### PR TITLE
Allow providing version for vNext

### DIFF
--- a/src/GitReleaseNotes/CommitGrouper.cs
+++ b/src/GitReleaseNotes/CommitGrouper.cs
@@ -8,9 +8,9 @@ namespace GitReleaseNotes
 {
     public class CommitGrouper
     {
-        public Dictionary<ReleaseInfo, List<Commit>> GetCommitsByRelease(IRepository gitRepo, TaggedCommit tagToStartFrom)
+        public Dictionary<ReleaseInfo, List<Commit>> GetCommitsByRelease(IRepository gitRepo, TaggedCommit tagToStartFrom, ReleaseInfo current = null)
         {
-            var currentRelease = new Tuple<ReleaseInfo, List<Commit>>(new ReleaseInfo(), new List<Commit>());
+            var currentRelease = new Tuple<ReleaseInfo, List<Commit>>(current ?? new ReleaseInfo(), new List<Commit>());
             var releases = new Dictionary<ReleaseInfo, List<Commit>> {{currentRelease.Item1, currentRelease.Item2}};
             var tagLookup = gitRepo.Tags.ToDictionary(t => t.Target.Sha, t => t);
             foreach (var commit in gitRepo.Commits.TakeWhile(c => tagToStartFrom == null || c != tagToStartFrom.Commit))

--- a/src/GitReleaseNotes/Program.cs
+++ b/src/GitReleaseNotes/Program.cs
@@ -97,7 +97,10 @@ namespace GitReleaseNotes
             else
                 tagToStartFrom = taggedCommitFinder.GetTag(arguments.FromTag);
 
-            var releases = new CommitGrouper().GetCommitsByRelease(gitRepo, tagToStartFrom);
+            var releases = new CommitGrouper().GetCommitsByRelease(
+                gitRepo, 
+                tagToStartFrom,
+                !string.IsNullOrEmpty(arguments.Version) ? new ReleaseInfo(arguments.Version, DateTimeOffset.Now, null, null) : null);
 
             IReleaseNotesStrategy generationStrategy;
             if (arguments.FromClosedIssues)


### PR DESCRIPTION
This uses the value of the /Version command line argument as the version of the current (i.e. vNext) release. If no value is specified then the original behavior will be used.

fixes #24
