### PR TITLE
Support JIRA

### DIFF
--- a/src/GitReleaseNotes/Extensions/GitReleaseNotesArgumentsExtensions.cs
+++ b/src/GitReleaseNotes/Extensions/GitReleaseNotesArgumentsExtensions.cs
@@ -19,7 +19,7 @@ namespace GitReleaseNotes
             throw new ArgumentException("Authentication context has an unsupported configuration");
         }
 
-        public static ReleaseNotesGenerationParameters ToContext(this GitReleaseNotesArguments arguments)
+        public static ReleaseNotesGenerationParameters ToParameters(this GitReleaseNotesArguments arguments)
         {
             return new ReleaseNotesGenerationParameters
             {

--- a/src/GitReleaseNotes/Program.cs
+++ b/src/GitReleaseNotes/Program.cs
@@ -35,7 +35,8 @@ namespace GitReleaseNotes
                 ShowHelp(modelBindingDefinition);
                 return 1;
             }
-            var context = arguments.ToContext();
+
+            var parameters = arguments.ToParameters();
             //if (!context.Validate())
             //{
             //    return -1;
@@ -48,12 +49,15 @@ namespace GitReleaseNotes
                 string outputFile = null;
                 var previousReleaseNotes = new SemanticReleaseNotes();
 
-                var outputPath = context.WorkingDirectory;
+                var outputPath = parameters.WorkingDirectory;
                 var outputDirectory = new DirectoryInfo(outputPath);
                 if (outputDirectory.Name == ".git")
                 {
                     outputPath = outputDirectory.Parent.FullName;
                 }
+
+                // In case the user puts in a relative path as current directory, first get the full path
+                outputPath = Path.GetFullPath(outputPath);
 
                 if (!string.IsNullOrEmpty(arguments.OutputFile))
                 {
@@ -63,7 +67,7 @@ namespace GitReleaseNotes
                     previousReleaseNotes = new ReleaseNotesFileReader(fileSystem, outputPath).ReadPreviousReleaseNotes(outputFile);
                 }
 
-                var releaseNotesGenerator = new ReleaseNotesGenerator(context);
+                var releaseNotesGenerator = new ReleaseNotesGenerator(parameters);
                 var releaseNotes = releaseNotesGenerator.GenerateReleaseNotesAsync(previousReleaseNotes).Result;
 
                 var releaseNotesOutput = releaseNotes.ToString();


### PR DESCRIPTION
Now GitTools.IssueTrackers supports JIRA, we can improve GitReleaseNotes to support it as well (should be out of the box, but doing some testing and minor improvements).