### PR TITLE
Use invariant culture when formatting dates

### DIFF
--- a/src/GitReleaseNotes/Models/SemanticReleaseNotes.cs
+++ b/src/GitReleaseNotes/Models/SemanticReleaseNotes.cs
@@ -55,7 +55,7 @@ namespace GitReleaseNotes
                     }
                     else if (release.When != null)
                     {
-                        builder.AppendLine(string.Format("# {0} ({1:dd MMMM yyyy})", release.ReleaseName,
+                        builder.AppendLine(string.Format(CultureInfo.InvariantCulture, "# {0} ({1:dd MMMM yyyy})", release.ReleaseName,
                             release.When.Value.Date));
                     }
                     else


### PR DESCRIPTION
`GitReleaseNotes.Tests.SemanticReleaseNotesTests.MultipleReleases` fails on non-English computers unless the date formatting in `GitReleaseNotes.SemanticReleaseNotes.ToString()` is done with `CultureInfo.InvariantCulture`. This PR fixes that problem.