### PR TITLE
No arguments should output help

### DIFF
--- a/src/GitReleaseNotes.Tests/GitReleaseNotes.Tests.csproj
+++ b/src/GitReleaseNotes.Tests/GitReleaseNotes.Tests.csproj
@@ -35,6 +35,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="ApprovalTests">
       <HintPath>..\packages\ApprovalTests.3.0.8\lib\net40\ApprovalTests.dll</HintPath>
     </Reference>
@@ -43,6 +47,10 @@
     </Reference>
     <Reference Include="ApprovalUtilities.Net45">
       <HintPath>..\packages\ApprovalUtilities.3.0.8\lib\net45\ApprovalUtilities.Net45.dll</HintPath>
+    </Reference>
+    <Reference Include="Args, Version=1.1.0.37402, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Args.1.1.2\lib\Net40\Args.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Atlassian.Jira, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Atlassian.SDK.2.5.0\lib\Atlassian.Jira.dll</HintPath>
@@ -94,6 +102,7 @@
     <Compile Include="GitRemoteRepositoryTests.cs" />
     <Compile Include="IssueTrackers\IssueNumberExtractor.cs" />
     <Compile Include="IssueTrackers\Jira\JiraIssueTrackerTests.cs" />
+    <Compile Include="ProgramTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReleaseFileWriterTests.cs" />
     <Compile Include="ReleaseNotesGeneratorTests.cs" />

--- a/src/GitReleaseNotes.Tests/ProgramTests.cs
+++ b/src/GitReleaseNotes.Tests/ProgramTests.cs
@@ -1,0 +1,48 @@
+﻿#region License
+
+// --------------------------------------------------
+// Copyright © OKB. All Rights Reserved.
+// 
+// This software is proprietary information of OKB.
+// USE IS SUBJECT TO LICENSE TERMS.
+// --------------------------------------------------
+
+#endregion
+
+using System;
+using System.IO;
+
+using Args;
+using Args.Help;
+using Args.Help.Formatters;
+
+using Shouldly;
+
+using Xunit;
+
+namespace GitReleaseNotes.Tests
+{
+    public class ProgramTests
+    {
+        [Fact]
+        public void NoArgumentsShouldOutputHelp()
+        {
+            using (var programWriter = new StringWriter())
+            {
+                Console.SetOut(programWriter);
+                Program.Main(new string[0]);
+
+                var modelBindingDefinition = Configuration.Configure<GitReleaseNotesArguments>();
+                var help = new HelpProvider().GenerateModelHelp(modelBindingDefinition);
+                var f = new ConsoleHelpFormatter(80, 1, 5);
+
+                using (var helpWriter = new StringWriter())
+                {
+                    f.WriteHelp(help, helpWriter);
+
+                    programWriter.ToString().ShouldContain(helpWriter.ToString());
+                }
+            }
+        }
+    }
+}

--- a/src/GitReleaseNotes.Tests/packages.config
+++ b/src/GitReleaseNotes.Tests/packages.config
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Antlr" version="3.5.0.2" targetFramework="net45" />
   <package id="ApprovalTests" version="3.0.8" targetFramework="net45" />
   <package id="ApprovalUtilities" version="3.0.8" targetFramework="net45" />
+  <package id="Args" version="1.1.2" targetFramework="net45" />
   <package id="Atlassian.SDK" version="2.5.0" targetFramework="net45" />
   <package id="GitTools.Core" version="1.0.0-unstable0043" targetFramework="net45" />
   <package id="GitTools.IssueTrackers" version="0.1.0-beta0002" targetFramework="net45" />

--- a/src/GitReleaseNotes/Program.cs
+++ b/src/GitReleaseNotes/Program.cs
@@ -14,13 +14,13 @@ namespace GitReleaseNotes
         // TODO Fix logging.. Just choose serilog or something which liblog picks up
         private static readonly ILog Log = GitReleaseNotesEnvironment.Log;
 
-        static int Main(string[] args)
+        public static int Main(string[] args)
         {
             GitReleaseNotesEnvironment.Log = new ConsoleLog();
 
             var modelBindingDefinition = Configuration.Configure<GitReleaseNotesArguments>();
 
-            if (args.Any(a => a == "/?" || a == "?" || a.Equals("/help", StringComparison.InvariantCultureIgnoreCase)))
+            if (!args.Any() ||args.Any(a => a == "/?" || a == "?" || a.Equals("/help", StringComparison.InvariantCultureIgnoreCase)))
             {
                 ShowHelp(modelBindingDefinition);
 
@@ -94,7 +94,9 @@ namespace GitReleaseNotes
         private static void ShowHelp(IModelBindingDefinition<GitReleaseNotesArguments> modelBindingDefinition, string reason = null)
         {
             var help = new HelpProvider().GenerateModelHelp(modelBindingDefinition);
-            var f = new ConsoleHelpFormatter();
+
+            var bufferWidth = Console.IsOutputRedirected ? 80 : Console.BufferWidth;
+            var f = new ConsoleHelpFormatter(bufferWidth, 1, 5);
             f.WriteHelp(help, Console.Out);
 
             if (reason != null)


### PR DESCRIPTION
This PR ensures that when no arguments are given to the executable, it doesn't throw an exception, but instead output the help text.